### PR TITLE
Integrate Google Drive resume import

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,15 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Google Drive Integration
+
+The app supports connecting a Google Drive account and automatically detecting resumes stored in Drive. Create the following environment variables in a `.env.local` file:
+
+```
+NEXT_PUBLIC_GOOGLE_CLIENT_ID=<your client id>
+NEXT_PUBLIC_GOOGLE_CLIENT_SECRET=<your client secret>
+NEXT_PUBLIC_GOOGLE_REDIRECT_URI=<authorized redirect uri>
+```
+
+After setting these variables run the app and navigate to `/google-drive` to connect your account.

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "react-dom": "^19.0.0",
     "tippy.js": "^6.3.7",
     "uuid": "^11.1.0",
-    "zustand": "^5.0.5"
+    "zustand": "^5.0.5",
+    "googleapis": "^132.0.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/app/(main)/google-drive/page.tsx
+++ b/src/app/(main)/google-drive/page.tsx
@@ -1,0 +1,59 @@
+"use client";
+import { useState, useEffect } from 'react';
+
+interface DriveFile { id: string; name: string; }
+
+export default function GoogleDrivePage() {
+  const [resumes, setResumes] = useState<DriveFile[]>([]);
+  const [connected, setConnected] = useState(false);
+
+  async function connect() {
+    const res = await fetch('/api/google-drive/auth');
+    const data = await res.json();
+    if (data.url) {
+      window.location.href = data.url;
+    }
+  }
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const code = params.get('code');
+    if (code && !connected) {
+      fetch(`/api/google-drive/token?code=${code}`)
+        .then(r => r.json())
+        .then(async ({ tokens }) => {
+          if (tokens) {
+            setConnected(true);
+            const res = await fetch('/api/google-drive/resumes', {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ tokens })
+            });
+            const data = await res.json();
+            setResumes(data.resumes || []);
+          }
+        });
+    }
+  }, [connected]);
+
+  return (
+    <div className="p-8 space-y-4">
+      <h1 className="text-2xl font-semibold text-text-primary">Google Drive Resumes</h1>
+      {!connected && (
+        <button onClick={connect} className="bg-blue-500 text-white px-4 py-2 rounded">
+          Connect Google Drive
+        </button>
+      )}
+      {connected && (
+        <div>
+          <h2 className="text-xl font-medium mb-2">Detected Resumes</h2>
+          <ul className="list-disc pl-5 space-y-1">
+            {resumes.map(f => (
+              <li key={f.id}>{f.name}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/api/google-drive/auth/route.ts
+++ b/src/app/api/google-drive/auth/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from 'next/server';
+import { generateAuthUrl } from '@/app/lib/googleDrive';
+
+export async function GET() {
+  const url = generateAuthUrl();
+  return NextResponse.json({ url });
+}

--- a/src/app/api/google-drive/resumes/route.ts
+++ b/src/app/api/google-drive/resumes/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from 'next/server';
+import { identifyResumeFiles } from '@/app/lib/googleDrive';
+
+export async function POST(req: Request) {
+  const body = await req.json();
+  if (!body.tokens) {
+    return NextResponse.json({ error: 'Missing tokens' }, { status: 400 });
+  }
+  const resumes = await identifyResumeFiles(body.tokens);
+  return NextResponse.json({ resumes });
+}

--- a/src/app/api/google-drive/token/route.ts
+++ b/src/app/api/google-drive/token/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from 'next/server';
+import { getTokens } from '@/app/lib/googleDrive';
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const code = searchParams.get('code');
+  if (!code) return NextResponse.json({ error: 'Missing code' }, { status: 400 });
+  const tokens = await getTokens(code);
+  return NextResponse.json({ tokens });
+}

--- a/src/app/lib/googleDrive.ts
+++ b/src/app/lib/googleDrive.ts
@@ -1,0 +1,57 @@
+import { google } from 'googleapis';
+
+const SCOPES = ['https://www.googleapis.com/auth/drive.readonly'];
+
+export const oauth2Client = new google.auth.OAuth2(
+  process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID,
+  process.env.NEXT_PUBLIC_GOOGLE_CLIENT_SECRET,
+  process.env.NEXT_PUBLIC_GOOGLE_REDIRECT_URI
+);
+
+export function generateAuthUrl() {
+  return oauth2Client.generateAuthUrl({
+    access_type: 'offline',
+    scope: SCOPES,
+    prompt: 'consent'
+  });
+}
+
+export async function getTokens(code: string) {
+  const { tokens } = await oauth2Client.getToken(code);
+  return tokens;
+}
+
+const KEYWORDS = ['education', 'experience', 'skills', 'objective', 'summary', 'professional'];
+
+function isResumeText(text: string): boolean {
+  const lower = text.toLowerCase();
+  let count = 0;
+  for (const word of KEYWORDS) {
+    if (lower.includes(word)) count += 1;
+  }
+  return count >= 2;
+}
+
+export async function identifyResumeFiles(tokens: any) {
+  oauth2Client.setCredentials(tokens);
+  const drive = google.drive({ version: 'v3', auth: oauth2Client });
+  const res = await drive.files.list({
+    fields: 'files(id,name,mimeType)',
+    q: "mimeType='application/pdf' or mimeType='application/vnd.openxmlformats-officedocument.wordprocessingml.document' or mimeType='application/msword'"
+  });
+  const files = res.data.files || [];
+  const resumes: { id: string; name: string }[] = [];
+  for (const f of files) {
+    if (!f.id) continue;
+    try {
+      const resp = await drive.files.export({ fileId: f.id, mimeType: 'text/plain' }, { responseType: 'text' });
+      const text = typeof resp.data === 'string' ? resp.data : '';
+      if (isResumeText(text)) {
+        resumes.push({ id: f.id, name: f.name || 'Unnamed' });
+      }
+    } catch {
+      // ignore parsing errors
+    }
+  }
+  return resumes;
+}


### PR DESCRIPTION
## Summary
- add Google Drive auth client and resume detection logic
- expose API routes for Google Drive authentication and listing resumes
- allow users to connect to Google Drive and view detected resumes
- document new environment variables for Google Drive setup
- include googleapis library in package.json

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848483297a08324968ab0653093c27b